### PR TITLE
Add ClickupIntegration module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Modules/ClickupIntegration"]
+	path = Modules/ClickupIntegration
+	url = git@github.com:ztersinc/freescout-clickup-module.git


### PR DESCRIPTION
### Summary

Added FreeScout ClickupIntegration Module.
Module is located at: https://github.com/ztersinc/freescout-clickup-module

#### Notes

* For additional notes on adding/cloning submodules
  * https://git-scm.com/book/en/v2/Git-Tools-Submodules