### PR TITLE
DIGDEV-16922 - DEV - View all conversation will now show the conversations …

### DIFF
--- a/app/Http/Controllers/CustomersController.php
+++ b/app/Http/Controllers/CustomersController.php
@@ -187,7 +187,7 @@ class CustomersController extends Controller
 
         $flash_message = __('Customer saved successfully.').' '.$flash_message;
         \Session::flash('flash_success_unescaped', $flash_message);
-        
+
         \Session::flash('customer.updated', 1);
 
         return redirect()->route('customers.update', ['id' => $id]);
@@ -227,15 +227,19 @@ class CustomersController extends Controller
     /**
      * View customer conversations.
      *
-     * @param intg $id
+     * @param int $id
+     * @param \Illuminate\Http\Request $request
      */
-    public function conversations($id)
+    public function conversations($id, Request $request)
     {
         $customer = Customer::findOrFail($id);
+        $mailbox_ids = $request->mailbox_id
+                    ? [$request->mailbox_id]
+                    : auth()->user()->mailboxesIdsCanView();
 
         $conversations = $customer->conversations()
             ->where('customer_id', $customer->id)
-            ->whereIn('mailbox_id', auth()->user()->mailboxesIdsCanView())
+            ->whereIn('mailbox_id', $mailbox_ids)
             ->orderBy('created_at', 'desc')
             ->paginate(Conversation::DEFAULT_LIST_SIZE);
 
@@ -379,7 +383,7 @@ class CustomersController extends Controller
                 }
 
                 if (!$response['msg']) {
-                   
+
                     $customer = Customer::create($request->email, $request->all());
                     if ($customer) {
                         $response['email']  = $request->email;
@@ -390,7 +394,7 @@ class CustomersController extends Controller
 
             // Conversations navigation
             case 'customers_pagination':
-            
+
                 $customers = app('App\Http\Controllers\ConversationsController')->searchCustomers($request, $user);
 
                 $response['status'] = 'success';

--- a/resources/views/conversations/partials/prev_convs_short.blade.php
+++ b/resources/views/conversations/partials/prev_convs_short.blade.php
@@ -3,7 +3,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a data-toggle="collapse" href=".collapse-conv-prev">{{ __("Previous Conversations") }} 
+                    <a data-toggle="collapse" href=".collapse-conv-prev">{{ __("Previous Conversations") }}
                         <b class="caret"></b>
                     </a>
                 </h4>
@@ -18,8 +18,8 @@
                             </li>
                         @endforeach
                     </ul>
-                    @if ($prev_conversations->hasMorePages()) 
-                        <a href="{{ route('customers.conversations', ['id' => $customer->id])}}" class="sidebar-block-link link-blue">{{ __("View all :number", ['number' => $prev_conversations->total()]) }}</a>
+                    @if ($prev_conversations->hasMorePages())
+                        <a href="{{ route('customers.conversations', ['id' => $customer->id, 'mailbox_id' => $conversation->mailbox_id])}}" class="sidebar-block-link link-blue">{{ __("View all :number", ['number' => '']) }}</a>
                     @endif
                 </div>
             </div>


### PR DESCRIPTION
…from the current mailbox when accesed via the conversation. It will show all when accessing via the customer profile

### Summary:

Clicking on `View All` previous conversation will now show only the conversations for the current Mailbox and not all of them.
All of them will appear only when accessed via the Customer profile.

**Preview:**
Only Current Mailbox conversation **(Should be 7)** in this example

![image](https://github.com/ztersinc/freescout/assets/611318/5e815f41-6df4-43d2-9a3c-a0cb13d3878f)

![image](https://github.com/ztersinc/freescout/assets/611318/724f6698-d42a-41db-90c7-59526dac2e47)

But when accessed via the Profile, it will show all of them (See difference in URL params with above):

![image](https://github.com/ztersinc/freescout/assets/611318/467e897b-fdf4-42b7-a855-ba6951edb538)

